### PR TITLE
remove jcenter; remove package from AndroidManifest; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@
 + </device-admin>
 
 ```
+
+Add the library types to your project by creating (or editing) a `index.d.ts` in your project root directory with the line:
+```
+declare module 'react-native-lock-task';
+```
+and then add it to your `tsconfig.json`
+```
+{
+  ...
+  "include" : ["index.d.ts"]
+}
+```
+
 ## Reinstall application
 * Start your emulator
 * Install project 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
     }
 
     dependencies {
@@ -13,11 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    package "com.rnlocktask"
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.rnlocktask">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
I encountered error while using the library with gradle 8.8, and this PR has been made to solve them. 

The three main problems were:
- the use of jcenter, in file `build.gradle`
- the use of attribute package in `AndroidManifest.xml`
- the absence of @types, which made impossible to use within a TS project